### PR TITLE
Fix typo in Windows SSH key path

### DIFF
--- a/SSH/shh_create.md
+++ b/SSH/shh_create.md
@@ -45,7 +45,7 @@ The key's randomart image is:
 
 ### On Windows
 
-the file might be here: "C:\Users\write_your_user_name\.ssh"
+the file might be here: "C:\Users\write_your_user_name\\.ssh"
 
 ### On Linux
 


### PR DESCRIPTION
This is caused by an interpretation of an escaped dot, which is not the intention in this case. Instead backslash needs to be escaped.